### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,34 @@ To automatically install the application, follow these steps:
   systemctl start/status/stop tblocker
   ```
 
+### Logrotate Configuration for Marzban Node
+
+The configuration below is necessary to prevent your system from being clogged by logs.
+
+```bash
+/var/lib/marzban-node/*.log {
+    size 50M
+    rotate 5
+    compress
+    missingok
+    notifempty
+    copytruncate
+}
+```
+You can install logrotate and apply this configuration with the following command:
+```bash
+sudo apt update && sudo apt install logrotate && sudo bash -c 'cat > /etc/logrotate.d/marzban-node <<EOF
+/var/lib/marzban-node/*.log {
+    size 50M
+    rotate 5
+    compress
+    missingok
+    notifempty
+    copytruncate
+}
+EOF' && logrotate -vf /etc/logrotate.d/marzban-node
+```
+
 ## Configuration
 
 After installation, you can configure the application's behavior via the configuration file located at: `/opt/tblocker/config.yaml`.

--- a/README.ru.md
+++ b/README.ru.md
@@ -101,6 +101,34 @@ volumes:
   systemctl start/status/stop tblocker
   ```
 
+### Конфигурация logrotate для Marzban Node
+
+Ниже представлена конфигурация, которая необходима для того, чтобы избежать переполнения вашей системы логами.
+
+```bash
+/var/lib/marzban-node/*.log {
+    size 50M
+    rotate 5
+    compress
+    missingok
+    notifempty
+    copytruncate
+}
+```
+Вы можете установить logrotate и применить эту конфигурацию с помощью следующей команды:
+```bash
+sudo apt update && sudo apt install logrotate && sudo bash -c 'cat > /etc/logrotate.d/marzban-node <<EOF
+/var/lib/marzban-node/*.log {
+    size 50M
+    rotate 5
+    compress
+    missingok
+    notifempty
+    copytruncate
+}
+EOF' && logrotate -vf /etc/logrotate.d/marzban-node
+```
+
 ## Конфигурация
 
 После установки вы можете настроить поведение приложения через файл конфигурации, который находится по пути: `/opt/tblocker/config.yaml`.


### PR DESCRIPTION
Add logrotate configuration for Marzban Node logs

This configuration limits each log file to 50MB and rotates/compresses logs, ensuring the system doesn't get clogged with excessive log files.