### PR TITLE
fix: [install.sh] SendAdminMessage ignored, check_placeholder optimisation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,11 +61,12 @@ fi
 
 check_placeholder() {
   local key="$1"
-  grep -q "$key: \"ADMIN_" "$CONFIG_PATH"
+  local value="$2"
+  grep -qE "^$key:\s*\"?$value\"?" "$CONFIG_PATH"
 }
 
 ask_for_input=true
-if ! check_placeholder "AdminBotToken" && ! check_placeholder "AdminChatID"; then
+if (! check_placeholder "AdminBotToken" "ADMIN_" && ! check_placeholder "AdminChatID" "ADMIN_") || check_placeholder "SendAdminMessage" "false"; then
   ask_for_input=false
   echo "Admin bot token and Chat ID are already set in the config. Skipping input."
 fi


### PR DESCRIPTION
This PR introduces the following **changes**:
	•	Replaced hardcoded checks for ADMIN_ values with a parameterized function.
	•	Improved script logic to skip interactive input correctly if config value `SendAdminMessage: false` are already set (was ignored in _install.sh_ due to this PR) for future automation with Ansible possibilities.

**Motivation and Context**
The previous implementation was tightly coupled to specific placeholder patterns and didn’t allow flexibility in detecting different placeholder values.  
It also lacked check for existing `SendAdminMessage: false` configuration, leading to asking for Telegram admin credentials even if it was disabled (in case when user uses SendWebhook option). 

**How to Reproduce**
	1.	Run install.sh with an existing config.yaml containing placeholder values:
              - 	` SendWebhook: true` 
              -        custom web hook url 
              -        `SendAdminMessage: false` 
              -        `AdminBotToken: "ADMIN_BOT_TOKEN"` & 
              -        `AdminChatID: "ADMIN_CHAT_ID"`
	3.	Confirm that the script ask_for_input=false still not the case and leads to interactive input ask. (Ruins ansible automation possability)