### PR TITLE
Implement webhook block duration sending

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -80,8 +80,8 @@ WebhookURL: "https://your-webhook-url.com/endpoint"
 
 # Опционально. Шаблон JSON для вебхука
 # Optional. JSON template for webhook
-# Available variables: %s - username, %s - ip, %s - server, %s - action (block/unblock), %s - timestamp
-WebhookTemplate: '{"username":"%s","ip":"%s","server":"%s","action":"%s","timestamp":"%s"}'
+# Available variables: %s - username, %s - ip, %s - server, %s - action (block/unblock), %d - block duration (minutes), %s - timestamp
+WebhookTemplate: '{"username":"%s","ip":"%s","server":"%s","action":"%s","duration":%d,"timestamp":"%s"}'
 
 # Опционально. Путь к директории для хранения файла с заблокированными IP-адресами.
 # Optional. Path to the directory for storing the blocked IP addresses file.

--- a/config/config.go
+++ b/config/config.go
@@ -148,7 +148,7 @@ func LoadConfig(configPath string) error {
 	if cfg.WebhookTemplate != "" {
 		WebhookTemplate = cfg.WebhookTemplate
 	} else {
-		WebhookTemplate = `{"username":"%s","ip":"%s","server":"%s","action":"%s","timestamp":"%s"}`
+		WebhookTemplate = `{"username":"%s","ip":"%s","server":"%s","action":"%s","duration":%d,timestamp":"%s"}`
 	}
 
 	StorageDir = cfg.StorageDir

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -225,6 +225,7 @@ func SendWebhook(username string, ip string, action string) {
 		ip,
 		config.Hostname,
 		action,
+		config.BlockDuration,
 		time.Now().Format(time.RFC3339),
 	)
 


### PR DESCRIPTION
This field can be useful for webhook-accepting services that need to:

- Log or display the exact duration of the block applied to a user or IP;
- Trigger additional workflows or alerts based on the length of the block (e.g., differentiate between short warnings and long-term bans);
- Provide better context for administrators or automated systems consuming the webhook;
- Support audit trails or incident reporting systems with more structured and actionable data.

⚠️ This feature is currently untested. However, the logic behind the addition is straightforward and should not introduce any breaking changes.