### PR TITLE
Fix missing quote in WebhookTemplate on empty var

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -148,7 +148,7 @@ func LoadConfig(configPath string) error {
 	if cfg.WebhookTemplate != "" {
 		WebhookTemplate = cfg.WebhookTemplate
 	} else {
-		WebhookTemplate = `{"username":"%s","ip":"%s","server":"%s","action":"%s","duration":%d,timestamp":"%s"}`
+		WebhookTemplate = `{"username":"%s","ip":"%s","server":"%s","action":"%s","duration":%d,"timestamp":"%s"}`
 	}
 
 	StorageDir = cfg.StorageDir


### PR DESCRIPTION
Should be `{"username":"%s","ip":"%s","server":"%s","action":"%s","duration":%d,"timestamp":"%s"}` but not affect logic if WebhookTemplate != "" 