### PR TITLE
Add IgnoreEmail option for TPROXY scenario

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ var (
 	TorrentTag    string
 	BlockMode     string
 	BypassIPSet   = make(map[string]struct{})
+	IgnoreEmail     bool
 	StorageDir    string
 
 	SendWebhook     bool
@@ -36,6 +37,7 @@ type Config struct {
 	UsernameRegex   string            `yaml:"UsernameRegex"`
 	BlockMode       string            `yaml:"BlockMode"`
 	BypassIPS       []string          `yaml:"BypassIPS"`
+	IgnoreEmail     bool              `yaml:"IgnoreEmail"`
 	SendWebhook     bool              `yaml:"SendWebhook"`
 	WebhookURL      string            `yaml:"WebhookURL"`
 	WebhookTemplate string            `yaml:"WebhookTemplate"`
@@ -58,6 +60,7 @@ func LoadConfig(configPath string) error {
 	LogFile = cfg.LogFile
 	BlockDuration = cfg.BlockDuration
 	TorrentTag = cfg.TorrentTag
+	IgnoreEmail = cfg.IgnoreEmail
 	SendWebhook = cfg.SendWebhook
 	WebhookURL = cfg.WebhookURL
 	WebhookHeaders = cfg.WebhookHeaders

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -59,6 +59,10 @@ WebhookHeaders:
 		t.Error("Expected SendWebhook to be true")
 	}
 
+	if !IgnoreEmail {
+		t.Error("Expected IgnoreEmail to be true")
+	}
+
 	if WebhookURL != "https://test.com/webhook" {
 		t.Errorf("Expected WebhookURL 'https://test.com/webhook', got '%s'", WebhookURL)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ BlockDuration: 15
 TorrentTag: "TEST_TORRENT"
 UsernameRegex: "user: (\\S+)"
 BlockMode: "iptables"
+IgnoreEmail: true
 BypassIPS:
   - "127.0.0.1"
   - "192.168.1.1"

--- a/main.go
+++ b/main.go
@@ -19,8 +19,6 @@ func main() {
 
 	log.Printf("XRay torrent-blocker: %s", Version)
 	log.Printf("Service started on %s", config.Hostname)
-	log.Printf("Version 1.0.1")
-	log.Printf(fmt.Sprintf("%t", config.IgnoreEmail))
 
 	utils.InitConntrackManager()
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	log.Printf("XRay torrent-blocker: %s", Version)
 	log.Printf("Service started on %s", config.Hostname)
 	log.Printf("Version 1.0.1")
-	log.Printf(config.IgnoreEmail)
+	log.Printf(fmt.Sprintf("%t", config.IgnoreEmail))
 
 	utils.InitConntrackManager()
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ func main() {
 
 	log.Printf("XRay torrent-blocker: %s", Version)
 	log.Printf("Service started on %s", config.Hostname)
+	log.Printf("Version 1.0.1")
+	log.Printf(config.IgnoreEmail)
 
 	utils.InitConntrackManager()
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -140,6 +140,10 @@ func parseLogEntryFast(line string) (ip, username string, valid bool) {
 		return "", "", false
 	}
 
+	if config.IgnoreEmail {
+		return ip, "__NO_USER_NAME__", true
+	}
+	
 	username = line[userStart:userEnd]
 	return ip, username, true
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -123,6 +123,9 @@ func parseLogEntryFast(line string) (ip, username string, valid bool) {
 
 	emailIndex := indexBytes(lineBytes, emailBytes)
 	if emailIndex == -1 {
+		if config.IgnoreEmail == true {
+		   return ip, "__NO_USER_NAME__", true
+	    }
 		return "", "", false
 	}
 
@@ -138,11 +141,6 @@ func parseLogEntryFast(line string) (ip, username string, valid bool) {
 
 	if userEnd <= userStart {
 		return "", "", false
-	}
-
-	if config.IgnoreEmail == true {
-		log.Println("TRUE TRUE TRUE")
-		return ip, "__NO_USER_NAME__", true
 	}
 	
 	username = line[userStart:userEnd]

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -141,6 +141,7 @@ func parseLogEntryFast(line string) (ip, username string, valid bool) {
 	}
 
 	if config.IgnoreEmail == true {
+		log.PrintLn("TRUE TRUE TRUE")
 		return ip, "__NO_USER_NAME__", true
 	}
 	

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -140,7 +140,7 @@ func parseLogEntryFast(line string) (ip, username string, valid bool) {
 		return "", "", false
 	}
 
-	if config.IgnoreEmail {
+	if config.IgnoreEmail == true {
 		return ip, "__NO_USER_NAME__", true
 	}
 	

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -123,7 +123,7 @@ func parseLogEntryFast(line string) (ip, username string, valid bool) {
 
 	emailIndex := indexBytes(lineBytes, emailBytes)
 	if emailIndex == -1 {
-		if config.IgnoreEmail == true {
+		if config.IgnoreEmail {
 		   return ip, "__NO_USER_NAME__", true
 	    }
 		return "", "", false

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -141,7 +141,7 @@ func parseLogEntryFast(line string) (ip, username string, valid bool) {
 	}
 
 	if config.IgnoreEmail == true {
-		log.PrintLn("TRUE TRUE TRUE")
+		log.Println("TRUE TRUE TRUE")
 		return ip, "__NO_USER_NAME__", true
 	}
 	


### PR DESCRIPTION
Log parser heavily relies on email filed being present and torrent blocker would complain if it's absent, but there are scenarios like TPROXY redirect from a Wireguard or OpenVPN (or, really, any other) tunnel to the inbound of XRAY, which would lead to the email field being absent from logfiles. For example, the log entry might look like this:

`2025/08/18 14:32:29 from 10.66.82.30:58584 accepted tcp:87.228.71.66:80 [all-in -> direct]`

Provided that it's a legitimate and acknowledged use-case, I've made quick and dirty PR to fix this. It essentially adds a new config entry and, if email is not present in logs, sends `__NO_USER_NAME__` to avoid breaking the rest of the code. 

I have to note that I'm not a Go programmer and I mostly have no idea of what I'm doing, but the PR seems to work, so please examine it carefully in case these changes break something that I'm not aware of. 